### PR TITLE
Update TCK user guide to build on JDK11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+/activation-tck-*.zip
+/classes/
+/docs/javadocs/
+/docs/ug/src/main/jbake/content/toc.adoc
+/version
+
 target/
-docs/ug/src/main/jbake/content/toc.adoc

--- a/docker/build_activationtck.sh
+++ b/docker/build_activationtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,12 +56,11 @@ which mvn
 mvn -version
 
 export ANT_OPTS="-DTS_HOME=$WORKSPACE -DJAVA_HOME=$JAVA_HOME -DJARPATH=$WORKSPACE"
-ant -f release.xml clean mvn
-
 export JAVA_HOME=$JDK11_HOME
 export PATH="$JAVA_HOME/bin:$PATH"
+
 if [[ "$LICENSE" == "EFTL" || "$LICENSE" == "eftl" ]]; then
-  ant -f release.xml core -DuseEFTLicensefile="true"
+  ant -f release.xml clean core -DuseEFTLicensefile="true"
 else
   ant -f release.xml core
 fi

--- a/docs/ug/pom.xml
+++ b/docs/ug/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,11 +35,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <!-- XXX - jbake needs an older version than this -->
-        <asciidoctorj.version>1.6.2</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <jruby.version>9.2.6.0</jruby.version>
+        <asciidoctorj.version>2.4.2</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.1.0</asciidoctorj.diagram.version>
+        <asciidoctorj.maven.plugin.version>2.1.0</asciidoctorj.maven.plugin.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <jbake.maven.plugin.version>0.3.3</jbake.maven.plugin.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>
         <doc.pdf>JAF-TCK-Users-Guide.pdf</doc.pdf>
@@ -57,8 +58,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>src/main/jbake/content</directory>
+                            <includes>
+                                <include>toc.adoc</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -68,8 +83,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <version>[1.8.0,)</version>
+                                    <message>You need JDK8 or newer</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -103,9 +118,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.blazebit</groupId>
+                <groupId>org.jbake</groupId>
                 <artifactId>jbake-maven-plugin</artifactId>
-                <version>1.0.0</version>
                 <configuration>
                     <outputDirectory>${site.output.dir}</outputDirectory>
                     <properties>
@@ -117,44 +131,14 @@
                         <id>build-site</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>build</goal>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.5</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-diagram</artifactId>
-                        <version>1.5.4</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${asciidoctor.maven.plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
-                        <version>${jruby.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>${asciidoctorj.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>${asciidoctorj.pdf.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <sourceDirectory>${project.build.directory}/book</sourceDirectory>
                     <sourceDocumentName>book.adoc</sourceDocumentName>
@@ -185,7 +169,7 @@
                         <id>generate-pdf-doc</id>
                         <phase>generate-resources</phase>
                         <goals>
-                                <goal>process-asciidoc</goal>
+                            <goal>process-asciidoc</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -193,7 +177,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-publish-plugin</artifactId>
-                <version>1.1</version>
                 <executions>
                     <execution>
                         <id>deploy-site</id>
@@ -209,21 +192,70 @@
                     </execution>
                 </executions>
             </plugin>
-	</plugins>
+        </plugins>
 
-	<pluginManagement>
-	    <plugins>
+        <pluginManagement>
+            <plugins>
                 <plugin>
                     <groupId>org.glassfish.doc</groupId>
                     <artifactId>glassfish-doc-maven-plugin</artifactId>
                     <version>1.3</version>
                 </plugin>
-		<plugin>
-		    <groupId>org.apache.maven.plugins</groupId>
-		    <artifactId>maven-assembly-plugin</artifactId>
-		    <version>2.4</version>
-		</plugin>
-	    </plugins>
-	</pluginManagement>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jbake</groupId>
+                    <artifactId>jbake-maven-plugin</artifactId>
+                    <version>${jbake.maven.plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj</artifactId>
+                            <version>${asciidoctorj.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-diagram</artifactId>
+                            <version>${asciidoctorj.diagram.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.freemarker</groupId>
+                            <artifactId>freemarker</artifactId>
+                            <version>${freemarker.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <version>${asciidoctorj.maven.plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-pdf</artifactId>
+                            <version>${asciidoctorj.pdf.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/docs/ug/src/main/jbake/jbake.properties
+++ b/docs/ug/src/main/jbake/jbake.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,5 +19,6 @@ render.tags=false
 render.sitemap=false
 render.archive=false
 render.feed=false
+render.index=false
 asciidoctor.option.safe=0
 asciidoctor.attributes.export=true

--- a/release.xml
+++ b/release.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,36 +48,34 @@
     </target>
 
     <target name="mvn">
-	<exec dir="${basedir}/docs/ug" executable="mvn"/>
-	<copy toDir="${basedir}/docs/html/">
-	    <fileset dir="${basedir}/docs/ug/target/staging/"/>
-	</copy>
-	<copy toDir="${basedir}/docs">
-	    <fileset dir="${basedir}/docs/ug/target/generated-docs/"
-		includes="*.pdf"/>
-	</copy>
+        <exec dir="${basedir}/docs/ug" executable="mvn">
+            <arg line="-B"/>
+        </exec>
     </target>
 
     <target name="copyEFTLicense" if="useEFTLicensefile">
-  	<copy tofile="${ts.home}/LICENSE.md" file="${ts.home}/LICENSE_EFTL.md" overwrite="true">
-  	</copy>
+        <copy tofile="${ts.home}/LICENSE.md" file="${ts.home}/LICENSE_EFTL.md" overwrite="true">
+        </copy>
     </target>
 
-    <target name="core" depends="build, javadoc, _create.version.file">
+    <target name="core" depends="build, mvn, javadoc, _create.version.file">
         <delete file="${zip.file}" quiet="true"/>
- 	<antcall target="copyEFTLicense"/>
+        <antcall target="copyEFTLicense"/>
         <zip destfile="${zip.file}">
-	    <zipfileset dir="${ts.home}/docs/"
-		includes="README.md"
-		prefix="activation-tck"/>
-	    <zipfileset dir="${ts.home}" 
+            <zipfileset dir="${ts.home}/docs/"
+                        includes="README.md"
+                        prefix="activation-tck"/>
+            <zipfileset dir="${ts.home}/docs/ug/target/staging/"
+                        prefix="activation-tck/docs/html/"/>
+            <zipfileset dir="${ts.home}/docs/ug/target/generated-docs/"
+                        includes="*.pdf"
+                        prefix="activation-tck/docs"/>
+            <zipfileset dir="${ts.home}"
                         includes="build.xml,
 			javatest.jar,
                         sigtest.jar,
                         version,
-                        docs/html/**,
                         docs/javadocs/**,
-                        docs/*.pdf,
                         tests/api/**,
                         tests/testsuite.html,
                         tests/testsuite.jtt,
@@ -90,8 +88,8 @@
                         classes/**,
                         LICENSE.md,
                         harness/**"
-                        prefix="activation-tck"/>                        	
-	</zip>
+                        prefix="activation-tck"/>
+        </zip>
     </target>
 
     <target name="_create.version.file">


### PR DESCRIPTION
Updates the TCK UG to allow build on JDK 11+, tested also on JDK 17-ea-b8 and everything - in terms of the user guide - seems to build correctly.

Also removed some overhead copying files when building through `release.xml`, sent maven to batch mode and updated `.gitignore`