### PR TITLE
JAF tck fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     <description>Builds and runs the project activation-tck.</description>
 
     <property name="version" value="2.0"/>
-    <property name="version.tck" value="2.0.0"/>
+    <property name="version.tck" value="2.0.1"/>
 
 
     <property environment="env"/>

--- a/docker/build_activationtck.sh
+++ b/docker/build_activationtck.sh
@@ -21,11 +21,6 @@ echo "export MAVEN_HOME=$MAVEN_HOME"
 echo "export PATH=$PATH"
 
 
-if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
-  export JAVA_HOME=${JDK11_HOME}
-  export PATH=$JAVA_HOME/bin:$PATH
-fi
-
 export TS_HOME=$WORKSPACE
 sed -i "s#^TS_HOME=.*#TS_HOME=$TS_HOME#g" $TS_HOME/lib/ts.jte
 sed -i "s#^JAVA_HOME=.*#JAVA_HOME=$JAVA_HOME#g" $TS_HOME/lib/ts.jte
@@ -56,7 +51,6 @@ which mvn
 mvn -version
 
 export ANT_OPTS="-DTS_HOME=$WORKSPACE -DJAVA_HOME=$JAVA_HOME -DJARPATH=$WORKSPACE"
-export JAVA_HOME=$JDK11_HOME
 export PATH="$JAVA_HOME/bin:$PATH"
 
 if [[ "$LICENSE" == "EFTL" || "$LICENSE" == "eftl" ]]; then

--- a/release.xml
+++ b/release.xml
@@ -49,7 +49,7 @@
 
     <target name="mvn">
         <exec dir="${basedir}/docs/ug" executable="mvn">
-            <arg line="-B"/>
+            <arg line="-B -V -Dmaven.repo.local=${ts.home}/.m2/repository"/>
         </exec>
     </target>
 


### PR DESCRIPTION
Build script shouldn't use JDK 11 parameter and start build with JDK 11(same parameter is used for both build and run).
